### PR TITLE
Fix userlist

### DIFF
--- a/Configuration/TCA/tx_beacl_acl.php
+++ b/Configuration/TCA/tx_beacl_acl.php
@@ -27,6 +27,7 @@ return array(
 			'config' => Array (
 				'type' => 'select',
 				'renderType' => 'selectSingle',
+				'default' => 0,
 				'items' => Array (
 					Array('LLL:EXT:be_acl/Resources/Private/Languages/locallang_db.xlf:tx_beacl_acl.type.I.0', '0'),
 					Array('LLL:EXT:be_acl/Resources/Private/Languages/locallang_db.xlf:tx_beacl_acl.type.I.1', '1'),
@@ -41,7 +42,7 @@ return array(
 			'config' => Array (
 				'type' => 'select',
 				'renderType' => 'selectSingle',
-				'default' => '0',
+				'default' => 0,
 				'itemsProcFunc' => 'JBartels\BeAcl\Utility\ObjectSelection->select',
 				'size' => 1,
 				'minitems' => 0,

--- a/Configuration/TCA/tx_beacl_acl.php
+++ b/Configuration/TCA/tx_beacl_acl.php
@@ -41,6 +41,7 @@ return array(
 			'config' => Array (
 				'type' => 'select',
 				'renderType' => 'selectSingle',
+				'default' => '0',
 				'itemsProcFunc' => 'JBartels\BeAcl\Utility\ObjectSelection->select',
 				'size' => 1,
 				'minitems' => 0,


### PR DESCRIPTION
added a default value to the field type otherwise the user list won't be shown without having to switch the type. The value of type when creating a new record is null. Since the user list is only shown if the type is 0, we would have to switch the type. Adding a default value 0 to the TCA for this field solves this problem.